### PR TITLE
MFP2-1913: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @gadgetjunkie @cp-macrofab
+* @metacollin @gpisacco @nalundgaard


### PR DESCRIPTION
I think we should probably archive this repo, but it's still in use in one place. I don't really want to apply any linting to it, since it's a public repo fork that needs to die, but here is an owners update.